### PR TITLE
AMS-26: reset user password via email

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,3 +5,6 @@ PORT=[portnumer]
 JWT_SECRET_KEY="Put your secret key"
 SEEDER_ADMIN_PASSWORD=[some admin password]
 SEEDER_SUPER_ADMIN_PASSWORD=[some super admin password]
+SENDGRID_API_KEY="Put your sendgrid api key"
+AMS_EMAIL=noreply@ams.com
+APP_URL_FRONTEND=http://localhost:5000/

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@hapi/joi": "15.0.3",
+    "@sendgrid/mail": "^6.5.5",
     "@types/bcrypt": "^3.0.0",
     "@types/bluebird": "^3.5.29",
     "@types/dotenv": "^8.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,9 @@ logger();
 const server = new ApolloServer({
   typeDefs,
   resolvers,
+  context: ({ req }) => ({
+    token: req.headers.authorization,
+  }),
 });
 
 server.listen({ port: process.env.PORT }).then(({ url }) => {

--- a/src/resolvers/__tests__/user.resolvers.spec.ts
+++ b/src/resolvers/__tests__/user.resolvers.spec.ts
@@ -1,5 +1,7 @@
 import { userResolver } from '../user.resolver';
 import dbConnection from '../../config/connectDb';
+import { generateToken } from '../../utils/user.utils';
+import { Iuser } from '../../interfaces/user.interfaces';
 
 
 describe('Test User Resolver', () => {
@@ -49,6 +51,48 @@ describe('Test User Resolver', () => {
     } catch (error) {
       expect(error.constructor.name).toEqual('AuthenticationError');
       expect(error.message).toEqual(message);
+    }
+  });
+
+  // password reset
+  it('Should send an email to the user if exists', async () => {
+    const email = 'foobar@gmail.com';
+    const spy = jest.spyOn(userResolver.Mutation, 'sendResetPasswordEmail');
+    await userResolver.Mutation.sendResetPasswordEmail(null, { email });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('Should not send an email if user email does not exists', async () => {
+    const email = 'wrong@gmail.com';
+    const message = 'User with this email does not exist';
+    try {
+      await userResolver.Mutation.sendResetPasswordEmail(null, { email });
+    } catch (error) {
+      expect(error.constructor.name).toEqual('AuthenticationError');
+      expect(error.message).toEqual(message);
+    }
+  });
+
+  it('Should reset password', async () => {
+    const password = 'butare';
+    const confirmPassword = 'butare';
+    const user = {
+      email: 'foobar@gmail.com',
+    };
+    const token = generateToken(user as Iuser);
+    const spy = jest.spyOn(userResolver.Mutation, 'sendResetPasswordEmail');
+    await userResolver.Mutation.resetPassword(null, { password, confirmPassword }, { token });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('Should reset password', async () => {
+    const password = 'butare';
+    const confirmPassword = 'butare';
+    const token = 'invalid token';
+    try {
+      await userResolver.Mutation.resetPassword(null, { password, confirmPassword }, { token });
+    } catch (error) {
+      expect(error.constructor.name).toEqual('Error');
     }
   });
 });

--- a/src/resolvers/user.resolver.ts
+++ b/src/resolvers/user.resolver.ts
@@ -1,8 +1,8 @@
 import UserService from '../services/user.services';
 import { generalValidator } from '../middlewares/general.validator';
-import { loginSchema } from '../utils/schema.utils';
+import { loginSchema, emailSchema, resetPasswordSchema } from '../utils/schema.utils';
 import { IloginData, Iuser } from '../interfaces/user.interfaces';
-import { generateToken } from '../utils/user.utils';
+import { generateToken, decodeToken } from '../utils/user.utils';
 
 
 export const userResolver = {
@@ -12,6 +12,17 @@ export const userResolver = {
       const res = await UserService.loginUser(args);
       const token = generateToken(res as Iuser);
       return { token };
+    },
+    sendResetPasswordEmail: async <T>(_: T, { email }): Promise<any> => {
+      generalValidator({ email }, emailSchema);
+      const res = await UserService.sendEmailToResetPassword(email);
+      return res;
+    },
+    resetPassword: async <T>(_: T, { password, confirmPassword }, { token }) => {
+      const { email } = await decodeToken(token);
+      generalValidator({ password, confirmPassword }, resetPasswordSchema);
+      const res = await UserService.resetPassword(password, email);
+      return res;
     },
   },
 };

--- a/src/services/user.services.ts
+++ b/src/services/user.services.ts
@@ -1,7 +1,8 @@
 import { AuthenticationError } from 'apollo-server';
 import { User } from '../sequelize/models/user.models';
-import { unHashPassword } from '../utils/user.utils';
+import { unHashPassword, hashPassword } from '../utils/user.utils';
 import { IloginData, Iuser } from '../interfaces/user.interfaces';
+import emailSender from '../utils/mailer/send.mailer';
 
 
 class UserService {
@@ -17,6 +18,25 @@ class UserService {
   static async findUserByEmail(email: string) {
     const user = await User.findOne({ where: { email } });
     return user;
+  }
+
+  static async sendEmailToResetPassword(email: string) {
+    const user = await this.findUserByEmail(email);
+    if (!user) {
+      throw new AuthenticationError('User with this email does not exist');
+    }
+    await emailSender(email, 'resetPassword', user);
+    return {
+      message: 'Link to reset your password sent, please check your email',
+    };
+  }
+
+  static async resetPassword(password: string, email: string) {
+    const hashedPassword = hashPassword(password);
+    await User.update({ password: hashedPassword }, { where: { email } });
+    return {
+      message: 'You have reset your password successful',
+    };
   }
 }
 

--- a/src/typeDefs/mutations/user.mutations.ts
+++ b/src/typeDefs/mutations/user.mutations.ts
@@ -11,5 +11,7 @@ export const userMutation = gql`
       avatar: String!
     ): User
     loginUser(email: String!, password: String!): Token
+    sendResetPasswordEmail(email: String!): Message
+    resetPassword(password: String!, confirmPassword: String!): Message
   }
 `;

--- a/src/typeDefs/types/user.types.ts
+++ b/src/typeDefs/types/user.types.ts
@@ -14,4 +14,8 @@ export const userType = gql`
     type Token {
         token: String
     }
+
+    type Message {
+        message: String
+    }
 `;

--- a/src/utils/mailer/send.mailer.ts
+++ b/src/utils/mailer/send.mailer.ts
@@ -1,0 +1,32 @@
+import 'dotenv/config';
+import sendGrid from '@sendgrid/mail';
+import * as emailTemplate from './templates';
+
+const sendEmailToUser = async (to: string, action: string, data) => {
+  const { SENDGRID_API_KEY, AMS_EMAIL, NODE_ENV } = process.env;
+
+  sendGrid.setApiKey(`${SENDGRID_API_KEY}`);
+  const emailSender = emailTemplate[action](data);
+  const message = {
+    to,
+    from: AMS_EMAIL as string,
+    subject: emailSender.subject,
+    text: 'AMS',
+    html: `<div style="background:#ECF0F1;width:100%;padding:20px 0;">
+          <div style="max-width:760px;margin:0 auto;background:#ffffff" font-size:1.2em>
+          <div style="background:#266cef;padding:10px;color:#ffffff;text-align:center;font-size:34px">
+          AMS
+          </div>
+          <div style="padding:20px;text-align:left;color:black" font-family: verdana>
+          ${emailSender.html}
+          </div>
+          </div>
+          <div style="padding:30px 10px;text-align:center;">
+          Copyright &copy; 2020
+          </div>
+          </div>`,
+  };
+  return NODE_ENV === 'test' ? true : sendGrid.send(message);
+};
+
+export default sendEmailToUser;

--- a/src/utils/mailer/templates/index.ts
+++ b/src/utils/mailer/templates/index.ts
@@ -1,0 +1,3 @@
+import resetPassword from './reset.password';
+
+export { resetPassword };

--- a/src/utils/mailer/templates/reset.password.ts
+++ b/src/utils/mailer/templates/reset.password.ts
@@ -1,0 +1,19 @@
+import 'dotenv/config';
+import { generateToken } from '../../user.utils';
+
+const { APP_URL_FRONTEND } = process.env;
+
+export default (data) => {
+  const message: any = {};
+  const token = generateToken(data);
+  const link = `${APP_URL_FRONTEND}/reset-password/${token}`;
+  message.subject = 'Reset your password - AMS';
+  message.html = `
+  Hello ${data.userName} </br>
+  <p style="font-size: 1rem; color:#266cef">You are receiving this because you have requested to reset your password,<br>
+   Click on the button bellow to complete the process<br>
+  <br><br><br>
+  <a href='${link}' style="margin:35px 0;padding:15px 35px;background:#266cef;color:#ffffff;clear:both;border-radius:30px;text-decoration:none" target='_blank'>Resert password Now</a></p>
+  `;
+  return message;
+};

--- a/src/utils/schema.utils.ts
+++ b/src/utils/schema.utils.ts
@@ -22,3 +22,12 @@ export const assetSchema = Joi.object().keys({
   assetImage: Joi.string(),
   assetCreatorId: Joi.number().required(),
 });
+
+export const emailSchema = Joi.object().keys({
+  email: Joi.string().email().required(),
+});
+
+export const resetPasswordSchema = Joi.object().keys({
+  password: Joi.string().required(),
+  confirmPassword: Joi.string().valid(Joi.ref('password')).required().options({ language: { any: { allowOnly: 'must match password' } } }),
+});

--- a/src/utils/user.utils.ts
+++ b/src/utils/user.utils.ts
@@ -24,3 +24,15 @@ export const unHashPassword = (
   hashedPassword: string,
   compare: string,
 ) => bcrypt.compareSync(hashedPassword, compare);
+
+export const hashPassword = (password: string) => bcrypt.hashSync(password, 10);
+
+export const decodeToken = async (token: string): Promise<any> => {
+  const result = await jwt.verify(token, JWT_SECRET_KEY!, (error, decoded) => {
+    if (error) {
+      return error;
+    }
+    return decoded;
+  });
+  return result;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1041,6 +1041,31 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sendgrid/client@^6.5.5":
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/@sendgrid/client/-/client-6.5.5.tgz#66cf569445d98a795998a894bb432a9939ead7c3"
+  integrity sha512-Nbfgo94gbWSL8PIgJfuHoifyOJJepvV8NQkkglctAEfb1hyozKhrzE6v1kPG/z4j0RodaTtXD5LJj/t0q/VhLA==
+  dependencies:
+    "@sendgrid/helpers" "^6.5.5"
+    "@types/request" "^2.48.4"
+    request "^2.88.0"
+
+"@sendgrid/helpers@^6.5.5":
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/@sendgrid/helpers/-/helpers-6.5.5.tgz#de6de9b94794fbf834b4f66a7d44af84bf736459"
+  integrity sha512-uRFEanalfss5hDsuzVXZ1wm7i7eEXHh1py80piOXjobiQ+MxmtR19EU+gDSXZ+uMcEehBGhxnb7QDNN0q65qig==
+  dependencies:
+    chalk "^2.0.1"
+    deepmerge "^4.2.2"
+
+"@sendgrid/mail@^6.5.5":
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/@sendgrid/mail/-/mail-6.5.5.tgz#45bef4e4878144304b6688867baa13179deecc4b"
+  integrity sha512-DSu8oTPI0BJFH60jMOG9gM+oeNMoRALFmdAYg2PIXpL+Zbxd7L2GzQZtmf1jLy/8UBImkbB3D74TjiOBiLRK1w==
+  dependencies:
+    "@sendgrid/client" "^6.5.5"
+    "@sendgrid/helpers" "^6.5.5"
+
 "@sinonjs/commons@^1.7.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.1.tgz#da5fd19a5f71177a53778073978873964f49acf1"
@@ -1105,6 +1130,11 @@
   dependencies:
     "@types/connect" "*"
     "@types/node" "*"
+
+"@types/caseless@*":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
+  integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
@@ -1321,6 +1351,16 @@
   dependencies:
     "@types/node" "*"
 
+"@types/request@^2.48.4":
+  version "2.48.4"
+  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.4.tgz#df3d43d7b9ed3550feaa1286c6eabf0738e6cf7e"
+  integrity sha512-W1t1MTKYR8PxICH+A4HgEIPuAC3sbljoEVfyZbeFJJDbr30guDspJri2XOaM2E+Un7ZjrihaDi7cf6fPa2tbgw==
+  dependencies:
+    "@types/caseless" "*"
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    form-data "^2.5.0"
+
 "@types/serve-static@*":
   version "1.13.3"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.3.tgz#eb7e1c41c4468272557e897e9171ded5e2ded9d1"
@@ -1333,6 +1373,11 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/tough-cookie@*":
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-2.3.6.tgz#c880579e087d7a0db13777ff8af689f4ffc7b0d5"
+  integrity sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ==
 
 "@types/validator@^12.0.1":
   version "12.0.1"
@@ -2666,6 +2711,11 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -3535,6 +3585,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
 
 form-data@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
### Description
- User should be able to reset the password via email
### How to test

Give explanations on how the reviewers can test the functionalities
- Clone this branch.
- `npm install`
- Use this mutation `sendResetPasswordEmail(email)` to send a link to be used to reset the password.
- Use this mutation `resetPassword(password, confirmPassword)` to reset your password but use the token that will be provided to you in the email sent to you. 

### How has this been tested?

- [ ]  Unit testing
- [x]  Integration testing
- [ ]  End-to-end testing

### Any background context you want to add
- N/A

### Screenshots
- N/A
### Jira

[Finishes AMS-26](https://amanilabs.atlassian.net/browse/AMS-26)