### PR TITLE
AMS-55: Enable super admin perform CRUD operation on addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "build": "yarn build-ts && yarn lint",
     "dev:watch": "nodemon -r ts-node src/index.ts",
-    "test": "jest --coverage",
+    "test": "jest --coverage --runInBand --forceExit",
     "pretest": "NODE_ENV=test yarn db:migrate:undo && NODE_ENV=test yarn db:migrate && NODE_ENV=test yarn db:seed:undo && NODE_ENV=test yarn db:seed",
     "db:migrate": "sequelize db:migrate",
     "db:migrate:undo": "sequelize db:migrate:undo:all",
@@ -69,10 +69,7 @@
     "ts-node": "^8.6.2"
   },
   "lint-staged": {
-    "src/**/*.(ts|js|tsx|jsx)": [
-      "yarn lint",
-      "git add"
-    ]
+    "src/**/*.(ts|js|tsx|jsx)": "yarn lint"
   },
   "husky": {
     "hooks": {

--- a/src/interfaces/address.interfaces.ts
+++ b/src/interfaces/address.interfaces.ts
@@ -1,0 +1,7 @@
+export interface Iaddress {
+  province: string;
+  district: string;
+  sector: string;
+  cell: string;
+  village: string;
+}

--- a/src/resolvers/__mocks__/resolvers.mocks.ts
+++ b/src/resolvers/__mocks__/resolvers.mocks.ts
@@ -1,0 +1,28 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const { SEEDER_SUPER_ADMIN_PASSWORD, SEEDER_ADMIN_PASSWORD } = process.env;
+
+export const newAddress = {
+  province: 'Coast',
+  district: 'Malindi',
+  sector: 'Mtangani',
+  cell: 'Palm Tree',
+  village: 'RedCross RD',
+};
+
+export const args1 = {
+  email: 'foobar@gmail.com',
+  password: SEEDER_SUPER_ADMIN_PASSWORD || '',
+};
+
+export const args2 = {
+  email: 'foobar1@gmail.com',
+  password: SEEDER_ADMIN_PASSWORD || '',
+};
+
+export const updateAddressArgs = {
+  id: '2',
+  district: 'Malindi',
+};

--- a/src/resolvers/__tests__/address.resolvers.spec.ts
+++ b/src/resolvers/__tests__/address.resolvers.spec.ts
@@ -1,0 +1,137 @@
+import { ApolloError, ForbiddenError } from 'apollo-server';
+import { addressResolver } from '../address.resolvers';
+import * as data from '../__mocks__/resolvers.mocks';
+import dbConnection from '../../config/connectDb';
+import { userResolver } from '../user.resolver';
+
+describe('Address Resolver Tests', () => {
+  let args: any;
+  let superAdminToken: any;
+  let adminToken: any;
+  beforeAll(async () => {
+    await dbConnection;
+    superAdminToken = await userResolver.Mutation.loginUser(null, data.args1);
+    adminToken = await userResolver.Mutation.loginUser(null, data.args2);
+  });
+  afterAll(async () => {
+    dbConnection.close();
+    jest.resetAllMocks();
+  });
+
+  it('Should  create new address', async () => {
+    const result = await addressResolver.Mutation.createAddress(
+      null, data.newAddress, superAdminToken,
+    );
+    expect(result.province).toEqual(data.newAddress.province);
+  });
+
+  it('Should  return error if user not superadmin during address creation', async () => {
+    args = data.newAddress;
+    try {
+      await addressResolver.Mutation.createAddress(null, args, adminToken);
+    } catch (error) {
+      expect(error).toEqual(new ForbiddenError('Sorry you\'re not authorized to perform this action'));
+    }
+  });
+
+  it('Should  return error if address already exists', async () => {
+    args = data.newAddress;
+    try {
+      await addressResolver.Mutation.createAddress(null, args, superAdminToken);
+    } catch (error) {
+      expect(error).toEqual(new ApolloError('Address already exists! Please check your input and try again'));
+    }
+  });
+  it('Should  return all addresses', async () => {
+    const result = await addressResolver.Query.addresses(null, args, adminToken);
+    expect(result[1].district).toEqual(data.newAddress.district);
+  });
+
+  it('Should return all addresses from cache if key is set', async () => {
+    const result = await addressResolver.Query.addresses(null, args, adminToken);
+    expect(result[1].village).toEqual(data.newAddress.village);
+    expect(result[1].cell).toEqual(data.newAddress.cell);
+  });
+
+  it('Should  return single address', async () => {
+    args = { id: 2 };
+    const result = await addressResolver.Query.address(null, args, adminToken);
+    expect(result && result.province).toEqual(data.newAddress.province);
+  });
+
+  it('Should  update a specific address', async () => {
+    args = data.updateAddressArgs;
+    const result = await addressResolver.Mutation.updateAddress(
+      null, args, superAdminToken,
+    );
+    expect(result && result.district).toEqual(data.updateAddressArgs.district);
+  });
+
+  it('Should  return error during update if not super-admin', async () => {
+    try {
+      args = data.updateAddressArgs;
+      await addressResolver.Mutation.updateAddress(null, args, adminToken);
+    } catch (error) {
+      expect(error).toEqual(new ForbiddenError('Sorry you\'re not authorized to perform this action'));
+    }
+  });
+
+  it('Should  return error during update if address not found', async () => {
+    try {
+      args = { id: '100' };
+      await addressResolver.Mutation.updateAddress(null, args, superAdminToken);
+    } catch (error) {
+      expect(error).toEqual(new ApolloError('Address with the Id: 100 not found!'));
+    }
+  });
+
+  it('Should  delete an address', async () => {
+    args = { id: 2 };
+    const result = await addressResolver.Mutation.deleteAddress(
+      null, args, superAdminToken,
+    );
+    expect(result.message).toEqual('Address with id:2 deleted successfully');
+  });
+
+  it('Should  return error during delete if not super-admin', async () => {
+    try {
+      args = { id: 2 };
+      await addressResolver.Mutation.deleteAddress(null, args, adminToken);
+    } catch (error) {
+      expect(error).toEqual(new ForbiddenError('Sorry you\'re not authorized to perform this action'));
+    }
+  });
+
+  it('Should return error during delete if id not found ', async () => {
+    try {
+      args = { id: 10 };
+      await addressResolver.Mutation.deleteAddress(null, args, superAdminToken);
+    } catch (error) {
+      expect(error).toEqual(new ApolloError(`Address with Id: ${args.id} not found.`));
+    }
+  });
+
+  it('Should return error if required role is not valid', async () => {
+    try {
+      args = { id: 10 };
+      await addressResolver.Mutation.deleteAddress(null, args, superAdminToken);
+    } catch (error) {
+      expect(error).toEqual(new ApolloError(`Address with Id: ${args.id} not found.`));
+    }
+  });
+
+  describe('Test Redis part', () => {
+    beforeAll(async () => {
+      args = { id: 1 };
+      await addressResolver.Mutation.deleteAddress(null, args, superAdminToken);
+    });
+
+    it('Should  return all addresses', async () => {
+      try {
+        await addressResolver.Query.addresses(null, args, adminToken);
+      } catch (error) {
+        expect(error).toEqual(new ApolloError('No addresses found at the moment. Please add one or come back later!'));
+      }
+    });
+  });
+});

--- a/src/resolvers/__tests__/create.user.resolvers.spec.ts
+++ b/src/resolvers/__tests__/create.user.resolvers.spec.ts
@@ -119,7 +119,7 @@ describe('Test user', () => {
   it('should update a user by super-admin', async () => {
     const spy = jest.spyOn(userResolver.Mutation, 'updateUser');
     const res = await userResolver.Mutation.updateUser(null,
-      { id: 1, input: updateSuperAdminInput }, superAdminToken);
+      { id: 5, input: updateSuperAdminInput }, superAdminToken);
     expect(spy).toHaveBeenCalled();
     expect(res.email).toEqual('updatedemail@gmail.com');
   });
@@ -179,7 +179,7 @@ describe('Test user', () => {
     const spy = jest.spyOn(userResolver.Query, 'users');
     const res = await userResolver.Query.users(null, { });
     expect(spy).toHaveBeenCalled();
-    expect(res[0].id).toBe(2);
+    expect(res[0].id).toBe(1);
   });
 
   it('should return all users from redis', async () => {

--- a/src/resolvers/address.resolvers.ts
+++ b/src/resolvers/address.resolvers.ts
@@ -1,0 +1,42 @@
+import { AddressService } from '../services/address.services';
+import { Iaddress } from '../interfaces/address.interfaces';
+import { generalValidator } from '../middlewares/general.validator';
+import { createAddressSchema, updateAddressSchema } from '../utils/schema.utils';
+import { userGroup, checkUserRole } from '../utils/user.utils';
+
+export const addressResolver = {
+  Query: {
+    addresses: async <T> (_: T, args, { token }) => {
+      await checkUserRole(token, userGroup.users);
+      return AddressService.getAllAddresses();
+    },
+
+    address: async <T> (root: T, args: any, { token }) => {
+      await checkUserRole(token, userGroup.users);
+      const address = AddressService.getAddressById(args.id);
+      return address;
+    },
+  },
+  Mutation: {
+    createAddress: async <T> (_: T, args: Iaddress, { token }) => {
+      await checkUserRole(token, userGroup.superAdmin);
+      generalValidator(args, createAddressSchema);
+      const { address } = await AddressService.createAddress(args);
+      return address;
+    },
+
+    updateAddress: async <T> (_: T, args: any, { token }) => {
+      await checkUserRole(token, userGroup.superAdmin);
+      generalValidator(args, updateAddressSchema);
+      const { id } = args;
+      await AddressService.getAddressById(id);
+      const { updatedAddress } = await AddressService.updateAddress(id, args);
+      return updatedAddress;
+    },
+
+    deleteAddress: async <T> (_: T, args: any, { token }) => {
+      await checkUserRole(token, userGroup.superAdmin);
+      return AddressService.deleteAddress(args.id);
+    },
+  },
+};

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,7 +1,13 @@
 import assetsResolver from './asset.resolvers';
 import { userResolver } from './user.resolver';
 import { institutionResolver } from './institution.resolvers';
+import { addressResolver } from './address.resolvers';
 
-const resolvers = [assetsResolver, userResolver, institutionResolver];
+const resolvers = [
+  assetsResolver,
+  userResolver,
+  institutionResolver,
+  addressResolver,
+];
 
 export default resolvers;

--- a/src/sequelize/migrations/20200229091455-create-Addresses-table.js
+++ b/src/sequelize/migrations/20200229091455-create-Addresses-table.js
@@ -5,23 +5,23 @@ module.exports.up = (queryInterface, DataTypes) => queryInterface.createTable('A
     primaryKey: true,
     type: DataTypes.INTEGER,
   },
-  Province: {
+  province: {
     type: DataTypes.STRING,
     allowNull: false,
   },
-  District: {
+  district: {
     type: DataTypes.STRING,
     allowNull: false,
   },
-  Sector: {
+  sector: {
     type: DataTypes.STRING,
     allowNull: false,
   },
-  Cell: {
+  cell: {
     type: DataTypes.STRING,
     allowNull: false,
   },
-  Village: {
+  village: {
     type: DataTypes.STRING,
     allowNull: false,
   },

--- a/src/sequelize/models/address.models.ts
+++ b/src/sequelize/models/address.models.ts
@@ -26,31 +26,31 @@ export class Address extends Model<Address> {
     allowNull: false,
     type: DataType.STRING,
   })
-  Province!: string;
+  province!: string;
 
   @Column({
     allowNull: false,
     type: DataType.STRING,
   })
-  District!: string;
+  district!: string;
 
   @Column({
     allowNull: false,
     type: DataType.STRING,
   })
-  Sector!: string;
+  sector!: string;
 
   @Column({
     allowNull: false,
     type: DataType.STRING,
   })
-  Cell!: string;
+  cell!: string;
 
   @Column({
     allowNull: false,
     type: DataType.STRING,
   })
-  Village!: string;
+  village!: string;
 
   @HasMany(() => Institution)
   institutions!: Institution[]

--- a/src/sequelize/seeders/2_address_seed.js
+++ b/src/sequelize/seeders/2_address_seed.js
@@ -1,10 +1,10 @@
 module.exports = {
   up: (queryInterface) => queryInterface.bulkInsert('Addresses', [{
-    Province: 'dddd',
-    District: 'dddddd',
-    Sector: 'ssssss',
-    Cell: 'aaafdd',
-    Village: 'sfasdfe',
+    province: 'dddd',
+    district: 'dddddd',
+    sector: 'ssssss',
+    cell: 'aaafdd',
+    village: 'sfasdfe',
     createdAt: new Date(),
     updatedAt: new Date(),
   }], {}),

--- a/src/services/address.services.ts
+++ b/src/services/address.services.ts
@@ -1,0 +1,64 @@
+import { ApolloError } from 'apollo-server';
+import { Address } from '../sequelize/models/address.models';
+import { Iaddress } from '../interfaces/address.interfaces';
+import Cache from '../config/redis';
+
+export class AddressService {
+  static async createAddress(args: Iaddress) {
+    const { cell, village } = args;
+    const [address, created] = await Address.findOrCreate({
+      where: { cell, village },
+      defaults: args,
+    });
+    if (created) {
+      await Cache.deleteAllWithPattern('addresses');
+      return { address };
+    }
+    throw new ApolloError('Address already exists! Please check your input and try again');
+  }
+
+  static async updateAddress(id: any, args: Iaddress) {
+    const [_, [updatedAddress]] = await Address.update(args, {
+      where: { id },
+      returning: true,
+    });
+
+    await Cache.deleteAllWithPattern('addresses');
+    return { updatedAddress };
+  }
+
+  static async getAllAddresses() {
+    let addresses = await Cache.fetch('addresses');
+    if (addresses) {
+      return addresses;
+    }
+    addresses = await Address.findAll();
+    if (addresses.length) {
+      await Cache.save('addresses', addresses);
+      return addresses;
+    }
+    throw new ApolloError('No addresses found at the moment. Please add one or come back later!');
+  }
+
+  static async getAddressById(id: any) {
+    let address = await Cache.fetch(`address:${id}`);
+    if (address) {
+      return address;
+    }
+    address = await Address.findOne({ where: { id } });
+    if (address) {
+      await Cache.save(`address:${id}`, address);
+      return address;
+    }
+    throw new ApolloError(`Address with the Id: ${id} not found!`);
+  }
+
+  static async deleteAddress(id: any) {
+    const deletedAddress = await Address.destroy({ where: { id } });
+    if (deletedAddress === 1) {
+      await Cache.delete('addresses');
+      return { message: `Address with id:${id} deleted successfully` };
+    }
+    throw new ApolloError(`Address with Id: ${id} not found.`);
+  }
+}

--- a/src/typeDefs/index.ts
+++ b/src/typeDefs/index.ts
@@ -8,9 +8,12 @@ export const typeDefs = [
   query,
   allMutations.userMutation,
   allMutations.assetMutation,
+  allMutations.addressMutation,
+  allQueries.addressQueries,
   allQueries.assetQueries,
   allTypes.assetType,
   allTypes.institutionType,
   allTypes.userType,
   allTypes.roleType,
+  allTypes.addressType,
 ];

--- a/src/typeDefs/mutations/address.mutations.ts
+++ b/src/typeDefs/mutations/address.mutations.ts
@@ -1,0 +1,24 @@
+import { gql } from 'apollo-server';
+
+export const addressMutation = gql`
+  extend type Mutation {
+    createAddress(
+      province: String!
+      district: String!
+      sector: String!
+      cell: String!
+      village: String!
+    ): Address
+    
+    updateAddress(
+      id: ID!
+      province: String
+      district: String
+      sector: String
+      cell: String
+      village: String
+    ): Address
+    
+    deleteAddress(id: ID!): Message!
+  } 
+  `;

--- a/src/typeDefs/mutations/index.ts
+++ b/src/typeDefs/mutations/index.ts
@@ -1,9 +1,11 @@
 import { userMutation } from './user.mutations';
 import { assetMutation } from './asset.mutations';
+import { addressMutation } from './address.mutations';
 
 const allMutations = {
   userMutation,
   assetMutation,
+  addressMutation,
 };
 
 export default allMutations;

--- a/src/typeDefs/queries/address.queries.ts
+++ b/src/typeDefs/queries/address.queries.ts
@@ -1,0 +1,8 @@
+import { gql } from 'apollo-server';
+
+export const addressQueries = gql`
+  extend type Query {
+    addresses: [Address!]!
+    address(id: Int): Address!
+  }
+`;

--- a/src/typeDefs/queries/index.ts
+++ b/src/typeDefs/queries/index.ts
@@ -1,7 +1,9 @@
 import { assetQueries } from './asset.queries';
+import { addressQueries } from './address.queries';
 
 const allQueries = {
   assetQueries,
+  addressQueries,
 };
 
 export default allQueries;

--- a/src/typeDefs/types/address.types.ts
+++ b/src/typeDefs/types/address.types.ts
@@ -1,0 +1,12 @@
+import { gql } from 'apollo-server';
+
+export const addressType = gql`
+  type Address {
+    id: ID!
+    province: String!
+    district: String!
+    sector: String!
+    cell: String!
+    village: String!
+  }
+`;

--- a/src/typeDefs/types/index.ts
+++ b/src/typeDefs/types/index.ts
@@ -2,12 +2,14 @@ import { assetType } from './asset.types';
 import { userType } from './user.types';
 import { roleType } from './role.types';
 import { institutionType } from './institution.types';
+import { addressType } from './address.types';
 
 export const allTypes = {
   assetType,
   userType,
   institutionType,
   roleType,
+  addressType,
 };
 
 export default allTypes;

--- a/src/utils/__tests__/user.utils.spec.ts
+++ b/src/utils/__tests__/user.utils.spec.ts
@@ -1,0 +1,41 @@
+import { ApolloError, ForbiddenError } from 'apollo-server';
+import { checkUserRole, decodeToken } from '../user.utils';
+import { userResolver } from '../../resolvers/user.resolver';
+import dbConnection from '../../config/connectDb';
+import * as data from '../../resolvers/__mocks__/resolvers.mocks';
+
+describe('checkUserRole tests', () => {
+  let adminToken: string;
+  beforeAll(async () => {
+    await dbConnection;
+    const { token } = await userResolver.Mutation.loginUser(null, data.args2);
+    adminToken = token;
+  });
+  afterAll(async () => {
+    dbConnection.close();
+  });
+  it('Should return error if wrong type of role is provided', async () => {
+    try {
+      await checkUserRole(adminToken, 12345);
+    } catch (error) {
+      expect(error).toEqual(new ApolloError('Sorry supply a valid role'));
+    }
+  });
+
+  it('Should return error if wrong role is provided', async () => {
+    const userRole = ['Kenya', 'Rwanda'];
+    try {
+      await checkUserRole(adminToken, userRole);
+    } catch (error) {
+      expect(error).toEqual(new ForbiddenError('Sorry you\'re not authorized to perform this action'));
+    }
+  });
+  it('Should return error if user is not logged in or supplies invalid token', async () => {
+    const token: any = 'invalidtoken';
+    try {
+      await decodeToken(token);
+    } catch (error) {
+      expect(error).toEqual(new ApolloError('Please login to proceed!!'));
+    }
+  });
+});

--- a/src/utils/schema.utils.ts
+++ b/src/utils/schema.utils.ts
@@ -46,3 +46,20 @@ export const userSchema = Joi.object().keys({
   phoneNo: Joi.strict().required().not(''),
   institutionId: Joi.number().required(),
 });
+
+export const createAddressSchema = Joi.object().keys({
+  province: Joi.string().required().min(3),
+  district: Joi.string().required().min(3),
+  sector: Joi.string().required().min(3),
+  cell: Joi.string().required().min(3),
+  village: Joi.string().required().min(3),
+});
+
+export const updateAddressSchema = Joi.object().keys({
+  id: Joi.string().required(),
+  province: Joi.string().min(3),
+  district: Joi.string().min(3),
+  sector: Joi.string().min(3),
+  cell: Joi.string().min(3),
+  village: Joi.string().min(3),
+});


### PR DESCRIPTION

### Description
- Enable super admin to create, update, view and delete addresses

### How to test
- Clone the repo and start the server `yarn dev:watch`
- write queries on the graphql playground: `addresses` to get all addresses, `address` to retrieve a single address.
-  Run mutations to create new addresses and institution/ delete or update existing ones

Give explanations on how the reviewers can test the functionalities

### How has this been tested?

- [ ]  Unit testing
- [X]  Integration testing
- [ ]  End-to-end testing

### Any background context you want to add

### Screenshots
<img width="444" alt="Screen Shot 2020-03-28 at 03 15 48" src="https://user-images.githubusercontent.com/21122345/77809811-7d742d00-70a2-11ea-8db6-78eeac3022e3.png">
### Jira

[Finishes  AMS-55]